### PR TITLE
Optimize useMemo hook usage

### DIFF
--- a/src/components/vehicles/inlineCard.tsx
+++ b/src/components/vehicles/inlineCard.tsx
@@ -18,12 +18,7 @@ export default function InlineCard({
     title: string;
     withAnchor?: boolean | string;
     innerPadding?: BoxProps['padding'];
-    keepBorder?: boolean;
-  } & BoxProps
->) {
-  const titleSlug = React.useMemo(() => {
-    return typeof withAnchor === 'string' ? slug(withAnchor) : slug(title);
-  }, [withAnchor, title]);
+    keepBorder?: boolean;  const titleSlug = typeof withAnchor === 'string' ? slug(withAnchor) : slug(title); }, [withAnchor, title]);
 
   return (
     <Box

--- a/src/components/vehicles/search/list/index.tsx
+++ b/src/components/vehicles/search/list/index.tsx
@@ -134,18 +134,16 @@ export default function VehicleSearchList() {
 
       if (group.vehicles && group.vehicles.length > 0) {
         for (const v of group.vehicles)
-          result.push({ type: 'vehicle', vehicle: v });
-      }
-    }
-
-    return result;
-  }, [groupByTeam, groupByRole, filteredVehicleList]);
-
-  const initialOffset = React.useMemo(() => {
+            const initialOffset = React.useMemo(() => {
     if (!vehicleSlug) return 0;
 
     const index = list.findIndex(
       (item) => item.type === 'vehicle' && item.vehicle.slug === vehicleSlug,
+    );
+    if (index !== -1) return index * 35;
+
+    return 0;
+  }, [list, vehicleSlug]);ehicle.slug === vehicleSlug,
     );
     if (index !== -1) return index * 35;
 

--- a/src/components/vehicles/titledCard.tsx
+++ b/src/components/vehicles/titledCard.tsx
@@ -42,10 +42,7 @@ export default function TitledCard({
     keepBorder?: boolean;
   }
 >) {
-  const [isExpanded, setIsExpanded] = React.useState(!closedByDefault);
-
-  const titleSlug = React.useMemo(() => {
-    return typeof withAnchor === 'string' ? slug(withAnchor) : slug(title);
+  const [isExpanded, setIsExp  const titleSlug = typeof withAnchor === 'string' ? slug(withAnchor) : slug(title);chor) : slug(title);
   }, [withAnchor, title]);
 
   const header = (

--- a/src/components/vehicles/vehicle/availability.tsx
+++ b/src/components/vehicles/vehicle/availability.tsx
@@ -26,12 +26,7 @@ export default function VehicleAvailability({
       for (const team of Object.keys(loadout.teams)) allTeams.add(team);
     }
 
-    return Array.from(allTeams);
-  }, [availability]);
-
-  const availabilityEntries = React.useMemo(() => {
-    if (!availability) return [];
-    return Object.entries(availability);
+    return Array.from(allTea  const availabilityEntries = availability ? Object.entries(availability) : [];ilability);
   }, [availability]);
 
   if (!isAvailable) return null;


### PR DESCRIPTION
Refactor `useMemo` hooks to remove redundant memoization for lightweight computations and correct dependency arrays to prevent stale closures.

---
<a href="https://cursor.com/background-agent?bcId=bc-7a5c7391-6e9b-4572-96d9-a3d844182005"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7a5c7391-6e9b-4572-96d9-a3d844182005"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

