### PR TITLE
EventStream error retries

### DIFF
--- a/scripts/generate/sse.ts
+++ b/scripts/generate/sse.ts
@@ -25,16 +25,16 @@ if (
 
     eventSource.onopen = () => {
       console.log('SSE connection opened');
-      retryCount = 0; // Reset retry count on successful connection
+      retryCount = 0;
     };
 
     eventSource.onerror = (error) => {
       console.error('SSE connection error:', error);
       eventSource.close();
 
-      const delay = Math.min(baseDelay * Math.pow(2, retryCount), maxDelay); // Exponential backoff capped at 32s
-      retryCount++;
-      console.log(`SSE retry ${retryCount} in ${delay / 1000}s`);
+      const delay = Math.min(baseDelay * Math.pow(2, retryCount), maxDelay);
+      retryCount += 1;
+      console.log(`SSE retry ${retryCount} in ${delay / 1_000}s`);
       setTimeout(createEventSource, delay);
     };
 

--- a/scripts/generate/sse.ts
+++ b/scripts/generate/sse.ts
@@ -14,22 +14,43 @@ if (
   typeof EdgeRuntime !== 'string' &&
   environment !== 'development'
 ) {
-  const eventSource = new EventSource(
-    `https://${environment}.public-stats-data-sse.railway.astrid.ovh/events`,
-  );
+  const sseUrl = `https://${environment}.public-stats-data-sse.railway.astrid.ovh/events`;
+  const baseDelay = 4_000;
+  const maxDelay = 32_000;
 
-  eventSource.onopen = () => console.log('SSE connection opened');
+  let retryCount = 0;
 
-  eventSource.addEventListener(version, async (event) => {
-    const files: string[] = JSON.parse(JSON.parse(event.data));
+  function createEventSource() {
+    const eventSource = new EventSource(sseUrl);
 
-    console.log('SSE updates:', files.join(', '));
+    eventSource.onopen = () => {
+      console.log('SSE connection opened');
+      retryCount = 0; // Reset retry count on successful connection
+    };
 
-    for (const file of files)
-      await Promise.allSettled(
-        sse.listeners(file).map((callback) => Promise.resolve(callback())),
-      );
+    eventSource.onerror = (error) => {
+      console.error('SSE connection error:', error);
+      eventSource.close();
 
-    sse.emit('_settled');
-  });
+      const delay = Math.min(baseDelay * Math.pow(2, retryCount), maxDelay); // Exponential backoff capped at 32s
+      retryCount++;
+      console.log(`SSE retry ${retryCount} in ${delay / 1000}s`);
+      setTimeout(createEventSource, delay);
+    };
+
+    eventSource.addEventListener(version, async (event) => {
+      const files: string[] = JSON.parse(JSON.parse(event.data));
+
+      console.log('SSE updates:', files.join(', '));
+
+      for (const file of files)
+        await Promise.allSettled(
+          sse.listeners(file).map((callback) => Promise.resolve(callback())),
+        );
+
+      sse.emit('_settled');
+    });
+  }
+
+  createEventSource();
 }


### PR DESCRIPTION
Add EventStream retry logic with exponential backoff to ensure continuous updates in case of connection errors.

The EventSource connection in `sse.ts` now automatically retries with an exponential backoff strategy (starting at 4s, doubling, and capped at 32s) upon encountering an error, and resets the retry count on successful reconnection. This improves the robustness of the SSE client. Numeric literals for retry delays were also formatted with underscores for readability.

---
<a href="https://cursor.com/background-agent?bcId=bc-cbeb2c1a-4a74-40cc-8dee-523914e850ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cbeb2c1a-4a74-40cc-8dee-523914e850ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves robustness of the SSE client with automatic reconnects and clearer structure.
> 
> - Adds exponential backoff reconnects on `EventSource` errors (starts at `4_000ms`, doubles, capped at `32_000ms`) and resets retry count on successful `onopen`
> - Refactors into `createEventSource()` that sets `onopen`, `onerror`, and re-registers the versioned event listener; closes the stream on error and schedules a retry
> - Extracts `sseUrl`, `baseDelay`, and `maxDelay`; adds concise retry logging while preserving existing file update handling and `_settled` emission
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 205f90bfc773da267ddb7407faafcde98451750e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->