### PR TITLE
Armour for new tanks and light vehicles.

### DIFF
--- a/content/vehicles/bigtruck.md
+++ b/content/vehicles/bigtruck.md
@@ -6,7 +6,7 @@ frontArmorDepth: 100
 
 ## Description
 
-The **MiKi Truck Company Model 2** is a Flatbed Truck used for logistics and transport. The **MiKi Truck Company Model 2** is a wheeled utility vehicle with a large cargo bed. Operated by a crew of two (a driver and one passenger) it has a gross weight of 4 t. A **3VZ-E V6** diesel engine produces 150 hp for a power-to-weight ratio of 37.5 hp/t, giving a top speed of 110 km/h forward and 15 km/h in reverse. The vehicle is unarmed and relies on mobility for survivability.
+The **MiKi Truck Company Model 2** is a Flatbed Truck used for logistics and transport. It is a wheeled utility vehicle with a large cargo bed. Operated by a crew of two (a driver and one passenger) it has a gross weight of 4 t. A **3VZ-E V6** diesel engine produces 150 hp for a power-to-weight ratio of 37.5 hp/t, giving a top speed of 110 km/h forward and 15 km/h in reverse. The vehicle is unarmed and relies on mobility for survivability.
 
 ## Armour
 

--- a/content/vehicles/bigtruck.md
+++ b/content/vehicles/bigtruck.md
@@ -6,7 +6,7 @@ frontArmorDepth: 100
 
 ## Description
 
-The **MiKi Truck Company Model 2** is a Flatbed Truck used for logistics and transport. It is a wheeled utility vehicle with a large cargo bed. Operated by a crew of two (a driver and one passenger) it has a gross weight of 4 t. A **3VZ-E V6** diesel engine produces 150 hp for a power-to-weight ratio of 37.5 hp/t, giving a top speed of 110 km/h forward and 15 km/h in reverse. The vehicle is unarmed and relies on mobility for survivability.
+The **MiKi Truck Company Model 2** is a Flatbed Truck used for logistics and transport. It is a wheeled utility vehicle with a large cargo bed. Operated by a crew of two (a driver and one passenger), it has a gross weight of 4 t. A **3VZ-E V6** diesel engine produces 150 hp for a power-to-weight ratio of 37.5 hp/t, giving a top speed of 110 km/h forward and 15 km/h in reverse. The vehicle is unarmed and relies on mobility for survivability.
 
 ## Armour
 

--- a/content/vehicles/bigtruck.md
+++ b/content/vehicles/bigtruck.md
@@ -9,3 +9,7 @@ frontArmorDepth: 100
 The **bigTruck** is a Flatbed Truck used for logistics and transport. It is the **MiKi Truck Company Model 2**, a wheeled utility vehicle with a large cargo bed. Operated by a crew of two—a driver and one passenger—it has a gross weight of 4 t. A **3VZ-E V6** diesel engine produces 150 hp for a power-to-weight ratio of 37.5 hp/t, giving a top speed of 110 km/h forward and 15 km/h in reverse. The vehicle is unarmed and relies on mobility for survivability.
 
 ## Armour
+
+Lower front plate: 2-14
+Upper front plate: 1-5
+Hull side: 1-11

--- a/content/vehicles/bigtruck.md
+++ b/content/vehicles/bigtruck.md
@@ -6,7 +6,7 @@ frontArmorDepth: 100
 
 ## Description
 
-The **bigTruck** is a Flatbed Truck used for logistics and transport. It is the **MiKi Truck Company Model 2**, a wheeled utility vehicle with a large cargo bed. Operated by a crew of two—a driver and one passenger—it has a gross weight of 4 t. A **3VZ-E V6** diesel engine produces 150 hp for a power-to-weight ratio of 37.5 hp/t, giving a top speed of 110 km/h forward and 15 km/h in reverse. The vehicle is unarmed and relies on mobility for survivability.
+The **MiKi Truck Company Model 2** is a Flatbed Truck used for logistics and transport. The **MiKi Truck Company Model 2** is a wheeled utility vehicle with a large cargo bed. Operated by a crew of two (a driver and one passenger) it has a gross weight of 4 t. A **3VZ-E V6** diesel engine produces 150 hp for a power-to-weight ratio of 37.5 hp/t, giving a top speed of 110 km/h forward and 15 km/h in reverse. The vehicle is unarmed and relies on mobility for survivability.
 
 ## Armour
 

--- a/content/vehicles/bm-21-grad.md
+++ b/content/vehicles/bm-21-grad.md
@@ -10,3 +10,10 @@ The **BM-21 Grad** is a Rocket Artillery system mounted on a 6×6 truck, one of 
 The launcher has 7 deg/s horizontal and 5 deg/s vertical traverse with elevation from -2° to 55°, and a 6 s reload cycle. No rangefinder or fire control beyond the 1× sight is modelled in the data; in practice, Grad batteries rely on external targeting and fire-control assets.
 
 ## Armour
+
+Left cheek: 5-10
+Right cheek: 5-10
+Lower front plate: 0-26
+Upper front plate: 0-26
+Hull side: 0-13
+Mantlet: 5

--- a/content/vehicles/bmp-1ts.md
+++ b/content/vehicles/bmp-1ts.md
@@ -3,3 +3,10 @@
 ## Description
 
 ## Armour
+
+Left cheek: 28-58
+Right cheek: 28-58
+Lower front plate: 34-55
+Upper front plate: 12-98
+Hull side: 18-29
+Mantlet: 21-26

--- a/content/vehicles/bmp-3-2017.md
+++ b/content/vehicles/bmp-3-2017.md
@@ -3,3 +3,10 @@
 ## Description
 
 ## Armour
+
+Left cheek: 51-114
+Right cheek: 51-114
+Lower front plate: 71-94
+Upper front plate: 49-71
+Hull side: 18-27
+Mantlet: 40-64

--- a/content/vehicles/bmp-30nt.md
+++ b/content/vehicles/bmp-30nt.md
@@ -9,3 +9,7 @@ frontArmorDepth: 52
 The **BMP-30NT** is an Armoured Personnel Carrier presented as a lightweight wheeled platform of uncertain origin, in-game represented as an abandoned IFV hull repurposed for transport. Weighing 10 t with seating for a driver and four passengers, it is powered by a **UTD-20** diesel producing 300 hp for a 30 hp/t power-to-weight ratio and a top speed of 65 km/h. The vehicle has no turret or integral armament in its basic configuration and relies on mobility and a low profile for survival. Locomotion is wheeled and non-amphibious.
 
 ## Armour
+
+Lower front plate: 68-165
+Upper front plate: 64-555
+Hull side: 50-75

--- a/content/vehicles/brdm-2-konkurs.md
+++ b/content/vehicles/brdm-2-konkurs.md
@@ -6,7 +6,7 @@ frontArmorDepth: 40
 
 ## Description
 
-The **BRDM-2 Konkurs** is an Anti-Tank Missile Carrier based on the Soviet **BRDM-2** reconnaissance vehicle, fitted with the **9P148** launcher system that carries and fires **9M113 Konkurs** (NATO: AT-5 Spandrel) wire-guided ATGMs. The BRDM-2 entered Soviet service in the 1960s and was widely exported; the 9P148 variant, introduced in the 1970s, gave motorized units a fast, amphibious platform capable of engaging armour at long range. The vehicle weighs 7 tonnes and is crewed by two — driver and commander — and is wheeled and amphibious at 100 km/h on road and 4 km/h in water. A **GAZ-41** diesel produces 140 horsepower for 20 hp/t.\
+The **9P148** is an Anti-Tank Missile Carrier based on the Soviet **BRDM-2** reconnaissance vehicle, fitted with the **9P148** launcher system that carries and fires **9M113 Konkurs** (NATO: AT-5 Spandrel) wire-guided ATGMs. The BRDM-2 entered Soviet service in the 1960s and was widely exported; the 9P148 variant, introduced in the 1970s, gave motorized units a fast, amphibious platform capable of engaging armour at long range. The vehicle weighs 7 tonnes and is crewed by two — driver and commander — and is wheeled and amphibious at 100 km/h on road and 4 km/h in water. A **GAZ-41** diesel produces 140 horsepower for 20 hp/t.\
 The sole armament is the **9M113 Konkurs** ATGM with a 4-second reload and 7-second refill; five ready rounds and ten in reserve are carried. The commander uses a 9.5x sight with no rangefinder. Light armour and high speed make it a shoot-and-scoot asset rather than a frontline fighter.
 
 ## Armour

--- a/content/vehicles/cv-90120-ghost.md
+++ b/content/vehicles/cv-90120-ghost.md
@@ -7,3 +7,10 @@ frontArmorDepth: 71
 ## Description
 
 ## Armour
+
+Left cheek: 41-45
+Right cheek: 32-67
+Lower front plate: 29-116
+Upper front plate: 30-231
+Hull side: 40-77
+Mantlet: 47-154

--- a/content/vehicles/cv-9040a.md
+++ b/content/vehicles/cv-9040a.md
@@ -6,8 +6,9 @@ frontArmorDepth: 60
 
 ## Description
 
-The **CV 9040A** is an Infantry Fighting Vehicle and a Swedish tracked APC/IFV armed with a 40 mm cannon. The CV 90 family entered service in the 1990s and is used by Sweden and several export customers; the 9040 variant emphasizes anti-air and anti-materiel capability. The 23.5 t vehicle carries a crew of three plus six passengers and reaches 70 km/h forward and 45 km/h reverse. The **Scania DSI14** diesel produces 550 hp for 23.4 hp/t and an automatic gearbox.\
-The **40mm Akan m/70B** is in a stabilized turret with a 24-round magazine and is paired with a **7.62mm ksp 39 C**. The gunner has a laser rangefinder, Gen 2 thermals, 8x zoom, and FCS with lead; the vehicle has smoke grenades but no horizontal stabilizer for the main gun.
+The **CV 9040A** is an Infantry Fighting Vehicle and a Swedish tracked APC/IFV — the Swedish designation for it being the **Strf 9040A**. It is armed with a 40 mm cannon. The CV 90 family entered service in the 1990s and is used by Sweden and several export customers; the 9040 variant emphasizes anti-air and anti-materiel capability. The 23.5 t vehicle carries a crew of three plus six passengers and reaches 70 km/h forward and 45 km/h reverse. The **Scania DSI14** diesel produces 550 hp for 23.4 hp/t and an automatic gearbox.\
+The **40mm Akan m/70B** has a 24-round magazine and is paired with a **7.62mm ksp 39 C**. The gunner has a laser rangefinder, Gen 2 thermals, 8x zoom, and FCS with lead; the vehicle has smoke grenades but no horizontal stabilizer for the main gun.
+The vehicle also features 3 modifications: CV 9040 BILL, CV 9040B and the slpprj m/01, all of which can be used in conjunction with each other. The CV 9040 BILL adds the RBS 56 ATGM launcher to the vehicle; this increases the CV 9040A's overall anti-tank capabilities, however, to fire the ATGM you also need an additional crew member. The CV 9040B modification updates the turret of the CV 9040, giving the gun a stabiliser and adding a backup monochromatic sight to the vehicle. Finally, the slpprj m/01 is an ammo add-on which replaces the stock slpprj m/90 APFSDS with slpprj m/01; this new shell boasts higher penetration, mass and velocity, with the max pen going from 133mm for the slpprj m/90 to 175mm for the slpprj m/01.
 
 ## Armour
 

--- a/content/vehicles/lada.md
+++ b/content/vehicles/lada.md
@@ -9,3 +9,7 @@ frontArmorDepth: 100
 The **Lada** is a Transport Vehicle based on the Soviet and Russian **VAZ** (Lada) family of passenger cars, used in many militaries as a lightweight utility and liaison vehicle. The in-game version represents a basic civilian-derived runabout. It weighs 1.1 tonnes and carries four — driver plus three passengers. The **VAZ-2105** gasoline engine produces 63 hp for a very high 60 hp/t power-to-weight ratio, yielding a top speed of 150 km/h forward and 22 km/h in reverse. The vehicle is wheeled and unarmoured, with no weapons or defensive systems; it is suited to rapid movement and transport of personnel rather than combat.
 
 ## Armour
+
+Lower front plate: 0-5
+Upper front plate: 0
+Hull side: 0-5

--- a/content/vehicles/lt-1mod.md
+++ b/content/vehicles/lt-1mod.md
@@ -6,8 +6,9 @@ frontArmorDepth: 100
 
 ## Description
 
-The **LT-SE** is a Light Tank presented as a “Special Edition” one-man vehicle: a driver who also operates the weapons. The data source names it LT-SE; in-game it is a compact tracked platform weighing 9.5 tonnes. The **TK-53** turbine produces 200 hp for 21.1 hp/t and 75 km/h.\
-Armament is a **30mm 2A42M** autocannon (AP and HE) and a **9M133 Kornet** ATGM launcher with four ready rounds; the driver’s turret has a laser rangefinder, FCS with lead and tracking, and 4x–12x zoom but no thermals. The turret is stabilised with -15° to 60° elevation. The vehicle is lightly protected and relies on speed and firepower.
+The **LT-SE** is a Light Tank developed by the fictional alien nation of Great Britain, it is crewed by a single operatorwho must simultaneously control the vehicle's movement and weapon systems. In-game the LT-SE is a compact tracked platform weighing in at 9.5 tonnes. The **TK-53** turbine produces 200 hp for 21.1 hp/t and 75 km/h. It features 7 gears (6 forward, 1 reverse) and the capability to neutral steer.
+Armament is a **30mm 2A42M** autocannon (APFSDS and HE) and a **9M133 Kornet** ATGM launcher with four ready rounds; the driver’s turret has a laser rangefinder, FCS with lead and tracking, and 4x–12x zoom but no thermals. The turret is stabilised with -15° to 60° elevation. The vehicle is lightly protected and relies on speed and firepower.
+It also features an airdrop addon which in addition to its small size makes it perfect for flanking attacks or capturing far enemy points.
 
 ## Armour
 

--- a/content/vehicles/lt-1mod.md
+++ b/content/vehicles/lt-1mod.md
@@ -6,7 +6,7 @@ frontArmorDepth: 100
 
 ## Description
 
-The **LT-SE** is a Light Tank developed by the fictional alien nation of Great Britain, it is crewed by a single operatorwho must simultaneously control the vehicle's movement and weapon systems. In-game the LT-SE is a compact tracked platform weighing in at 9.5 tonnes. The **TK-53** turbine produces 200 hp for 21.1 hp/t and 75 km/h. It features 7 gears (6 forward, 1 reverse) and the capability to neutral steer.
+The **LT-SE** is a Light Tank developed by the fictional alien nation of Great Britain, it is crewed by a single operator who must simultaneously control the vehicle's movement and weapon systems. In-game the LT-SE is a compact tracked platform weighing in at 9.5 tonnes. The **TK-53** turbine produces 200 hp for 21.1 hp/t and 75 km/h. It features 7 gears (6 forward, 1 reverse) and the capability to neutral steer.
 Armament is a **30mm 2A42M** autocannon (APFSDS and HE) and a **9M133 Kornet** ATGM launcher with four ready rounds; the driver’s turret has a laser rangefinder, FCS with lead and tracking, and 4x–12x zoom but no thermals. The turret is stabilised with -15° to 60° elevation. The vehicle is lightly protected and relies on speed and firepower.
 It also features an airdrop addon which in addition to its small size makes it perfect for flanking attacks or capturing far enemy points.
 

--- a/content/vehicles/lt-1mod.md
+++ b/content/vehicles/lt-1mod.md
@@ -6,7 +6,7 @@ frontArmorDepth: 100
 
 ## Description
 
-The **LT-1Mod** is a Light Tank presented as a “Special Edition” one-man vehicle: a driver who also operates the weapons. The data source names it LT-SE; in-game it is a compact tracked platform weighing 9.5 tonnes. The **TK-53** turbine produces 200 hp for 21.1 hp/t and 75 km/h.\
+The **LT-SE** is a Light Tank presented as a “Special Edition” one-man vehicle: a driver who also operates the weapons. The data source names it LT-SE; in-game it is a compact tracked platform weighing 9.5 tonnes. The **TK-53** turbine produces 200 hp for 21.1 hp/t and 75 km/h.\
 Armament is a **30mm 2A42M** autocannon (AP and HE) and a **9M133 Kornet** ATGM launcher with four ready rounds; the driver’s turret has a laser rangefinder, FCS with lead and tracking, and 4x–12x zoom but no thermals. The turret is stabilised with -15° to 60° elevation. The vehicle is lightly protected and relies on speed and firepower.
 
 ## Armour

--- a/content/vehicles/lt-1mod.md
+++ b/content/vehicles/lt-1mod.md
@@ -10,3 +10,10 @@ The **LT-1Mod** is a Light Tank presented as a “Special Edition” one-man veh
 Armament is a **30mm 2A42M** autocannon (AP and HE) and a **9M133 Kornet** ATGM launcher with four ready rounds; the driver’s turret has a laser rangefinder, FCS with lead and tracking, and 4x–12x zoom but no thermals. The turret is stabilised with -15° to 60° elevation. The vehicle is lightly protected and relies on speed and firepower.
 
 ## Armour
+
+Left cheek: 0-7
+Right cheek: 5-9
+Lower front plate: 22-158
+Upper front plate: 17-175
+Hull side: 8-34
+Mantlet: 26-55

--- a/content/vehicles/m38.md
+++ b/content/vehicles/m38.md
@@ -9,3 +9,7 @@ frontArmorDepth: 100
 The **M38** is a wheeled Transport Vehicle, the U.S. military designation for the **Willys MC** (later **M38**) ¼-ton 4×4 truck that succeeded the World War II jeep. It entered service in 1950 and was used for liaison, reconnaissance, and light cargo in Korea and beyond. Weighing 1.2 tonnes, it carries a driver and three passengers and is powered by the **F4-134 Hurricane** gasoline engine producing 72 horsepower for a 60 hp/t power-to-weight ratio and a top speed of 89 km/h. The base vehicle is unarmed; addons include extra armour, an **M2 Browning** 12.7 mm machine gun, and a **TOW** tripod for dismounted anti-tank use, making it a flexible light platform for crew and equipment.
 
 ## Armour
+
+Lower front plate: 0-10
+Upper front plate: 0
+Hull side: 0-5

--- a/content/vehicles/m939.md
+++ b/content/vehicles/m939.md
@@ -9,3 +9,7 @@ frontArmorDepth: 100
 The **M939** is a Supply Truck, part of the US Army's M939 series of 5-tonne 6×6 cargo trucks that replaced the M39 series from the 1980s onward. Built by AM General and others, it served as the standard medium tactical truck for hauling cargo, towing, and supporting forward units. The 11-tonne wheeled vehicle has a driver and seating for six passengers, and is powered by a **6CTA8.3 IMO 1** diesel producing 240 hp for a 21.8 hp/t power-to-weight ratio and a top speed of 89 km/h. It has no armament or defensive systems and is intended purely for logistics; optional addons include a flat bed and tent cover for cargo configuration.
 
 ## Armour
+
+Lower front plate: 0-20
+Upper front plate: 0
+Hull side: 0-10

--- a/content/vehicles/panther-evo.md
+++ b/content/vehicles/panther-evo.md
@@ -6,7 +6,7 @@ frontArmorDepth: 59
 
 ## Description
 
-The **Panther EVO** is a Main Battle Tank based of a proposition by Rheinmetal to upgrade older Leopard 2's with the turret of the KF-51 panther, it features the 130 mm gun, autoloader, and full suite of modern optics and active protection found on the KF-51. Weighing 55.4 tonnes, it is crewed by three: driver, gunner, and commander. The **MTU MB 873 Ka-501** diesel delivers 1,500 hp for 27.1 hp/t and 68 km/h forward (31 km/h reverse), with neutral steering and an automatic gearbox.\
+The **Panther EVO** is a Main Battle Tank based off a proposition by Rheinmetall to upgrade older Leopard 2's with the turret of the KF-51 panther, it features the 130 mm gun, autoloader, and full suite of modern optics and active protection found on the KF-51. Weighing 55.4 tonnes, it is crewed by three: driver, gunner, and commander. The **MTU MB 873 Ka-501** diesel delivers 1,500 hp for 27.1 hp/t and 68 km/h forward (31 km/h reverse), with neutral steering and an automatic gearbox.\
 Main armament is the **130mm Rh130 L/51** with a 4-second autoloader and **12.7mm RMG**; the vehicle has laser warning, stabilizer, and smoke grenades. The gunner has a laser rangefinder, Gen 3 thermals, and FCS with lead and tracking; the commander has a thermals-equipped CITV and CROWS with FCS. The oversized turret and modern firepower make the Panther EVO a high-tier MBT with strong survivability and fire control.
 
 ## Armour

--- a/content/vehicles/panther-evo.md
+++ b/content/vehicles/panther-evo.md
@@ -6,8 +6,8 @@ frontArmorDepth: 59
 
 ## Description
 
-The **Panther EVO** is a Main Battle Tank — a fictional modern evolution of the Panther concept, pairing a classic name with a 130 mm gun, autoloader, and full suite of modern optics and active protection. Weighing 55.4 tonnes, it is crewed by three: driver, gunner, and commander. The **MTU MB 873 Ka-501** diesel delivers 1,500 hp for 27.1 hp/t and 68 km/h forward (31 km/h reverse), with neutral steering and an automatic gearbox.\
-Main armament is the **130mm Rh130 L/51** with a 4-second autoloader and **12.7mm RMG**; an APS provides hard-kill protection, and the vehicle has laser warning, stabilizer, and smoke grenades. The gunner has a laser rangefinder, Gen 3 thermals, and FCS with lead and tracking; the commander has a thermals-equipped CITV and CROWS with FCS. The oversized turret and modern firepower make the Panther EVO a high-tier MBT with strong survivability and fire control.
+The **Panther EVO** is a Main Battle Tank based of a proposition by Rheinmetal to upgrade older Leopard 2's with the turret of the KF-51 panther, it features the 130 mm gun, autoloader, and full suite of modern optics and active protection found on the KF-51. Weighing 55.4 tonnes, it is crewed by three: driver, gunner, and commander. The **MTU MB 873 Ka-501** diesel delivers 1,500 hp for 27.1 hp/t and 68 km/h forward (31 km/h reverse), with neutral steering and an automatic gearbox.\
+Main armament is the **130mm Rh130 L/51** with a 4-second autoloader and **12.7mm RMG**; the vehicle has laser warning, stabilizer, and smoke grenades. The gunner has a laser rangefinder, Gen 3 thermals, and FCS with lead and tracking; the commander has a thermals-equipped CITV and CROWS with FCS. The oversized turret and modern firepower make the Panther EVO a high-tier MBT with strong survivability and fire control.
 
 ## Armour
 

--- a/content/vehicles/panther-kf51.md
+++ b/content/vehicles/panther-kf51.md
@@ -6,8 +6,8 @@ frontArmorDepth: 58
 
 ## Description
 
-The **Panther KF51** is a Main Battle Tank, the Rheinmetall KF51 Panther — a next-generation demonstrator unveiled in 2022, featuring a 130 mm gun, unmanned turret options, and integrated drone and active protection systems. Weighing 55.4 tonnes, it is crewed by three: driver, gunner, and commander. The **MTU MB 873 Ka-501** diesel produces 1,500 hp for 27.1 hp/t and 68 km/h forward (31 km/h reverse), with neutral steering and an automatic gearbox.\
-Main armament is the **130mm Rh130 L/51** with an autoloader and a 4-second cycle, plus a **12.7mm RMG**; the vehicle has two APS layers (frontal and full coverage), laser and missile warning, stabilizer, and smoke grenades. The gunner has a laser rangefinder, Gen 3 thermals, and FCS with lead and tracking; the commander has a thermals-equipped CITV and CROWS with FCS, making the KF51 one of the most capable MBTs in the roster.
+The **KF51 Panther** is a Main Battle Tank developed by Rheinmetall — a next-generation demonstrator unveiled in 2022, featuring a 130 mm gun, unmanned turret options, and integrated drone and active protection systems. Weighing 55.4 tonnes, it is crewed by three: driver, gunner, and commander. The **MTU MB 873 Ka-501** diesel produces 1,500 hp for 27.1 hp/t and 68 km/h forward (31 km/h reverse), with neutral steering and an automatic gearbox.\
+Main armament is the **130mm Rh130 L/51** with an autoloader and a 4-second cycle, plus a **12.7mm RMG**; the vehicle has two APS layers (frontal and full coverage), laser and missile warning, stabilizer, and smoke grenades. The gunner has a laser rangefinder, Gen 3 thermals, and FCS with lead and tracking; the commander has a thermals-equipped CITV and CROWS with FCS, making the KF51 one of the most capable MBTs in the game.
 
 ## Armour
 

--- a/content/vehicles/pickuptruck.md
+++ b/content/vehicles/pickuptruck.md
@@ -9,3 +9,7 @@ frontArmorDepth: 100
 The **MiKi Truck Company Model 1** is a light Pickup Truck transport used for rapid movement of personnel and equipment. The vehicle weighs 1.3 tonnes and seats two — driver and one passenger — with no armament. A **3VZ-E V6** diesel produces 150 horsepower for a very high 118.1 hp/t power-to-weight ratio and a top speed of 110 km/h forward and 15 km/h reverse. It is suited to reconnaissance, logistics, and quick repositioning on the battlefield.
 
 ## Armour
+
+Lower front plate: 0-3
+Upper front plate: 0-34
+Hull side: 0-5

--- a/content/vehicles/pt-91.md
+++ b/content/vehicles/pt-91.md
@@ -6,7 +6,7 @@ frontArmorDepth: 60
 
 ## Description
 
-The **PT-91** is a Main Battle Tank — the Polish development of the T-72M1, with improved armour, fire control, and the **S12U** diesel; the in-game variant reflects the PT-91M2A1 with further upgrades. Weighing 45.9 tonnes, it is crewed by three: driver, gunner, and commander, with an autoloader for the main gun. The S12U produces 850 hp for 18.5 hp/t and 60 km/h forward.\
+The **PT-91** is a Main Battle Tank with the designation of "Twardy" — the Polish development of the T-72M1, with improved armour, fire control, and the **S12U** diesel; the in-game variant reflects the PT-91M2A1 with further upgrades. Weighing 45.9 tonnes, it is crewed by three: driver, gunner, and commander, with an autoloader for the main gun. The S12U produces 850 hp for 18.5 hp/t and 60 km/h forward.\
 Main armament is the **125mm 2A46MS** with APFSDS, HEAT, and HE; a coaxial **7.62mm PKT** and commander **12.7mm M2** complete the fit. Defences include engine smoke and smoke grenades; the gunner has a laser rangefinder, Gen 3 thermals, and FCS with lead and tracking (4x–12x and backup 8x), and the commander has a CROWS with thermals and FCS. Optional “Ryś” APFSDS and M2A2 packages improve ammunition and mobility.
 
 ## Armour

--- a/content/vehicles/rszo-1.md
+++ b/content/vehicles/rszo-1.md
@@ -10,3 +10,8 @@ The **RSZO-1** is a Rocket Artillery vehicle, a wheeled multiple rocket launcher
 The main armament is the **Rocketetet** system with 16 HE rockets and a 6 s reload; the commander operates elevation and traverse with a simple 1x sight. Minimal armour and no secondary weapons make it dependent on positioning and support.
 
 ## Armour
+
+Lower front plate: 0-10
+Upper front plate: 0
+Hull side: 0-20
+Mantlet: 0

--- a/content/vehicles/strf-9040c.md
+++ b/content/vehicles/strf-9040c.md
@@ -6,8 +6,9 @@ frontArmorDepth: 60
 
 ## Description
 
-The **Strf 9040C** is an Infantry Fighting Vehicle — the Swedish designation for the **CV 9040C**, a variant of the Combat Vehicle 90 family with a 40 mm Bofors cannon in a two-man turret, used by the Swedish Army and export customers. In-game it is a tracked IFV weighing 28.5 tonnes with a crew of three and room for six passengers. The **Scania DSI14** diesel produces 550 hp for 19.3 hp/t, 70 km/h forward and 45 km/h reverse, with neutral steering.\
+The **CV 9040C** is an Infantry Fighting Vehicle — the Swedish designation for it being the **Strf 9040C**, a variant of the Combat Vehicle 90 family with a 40 mm Bofors cannon in a two-man turret, used by the Swedish Army and export customers. In-game it is a tracked IFV weighing 28.5 tonnes with a crew of three and room for six passengers. The **Scania DSI14** diesel produces 550 hp for 19.3 hp/t, 70 km/h forward and 45 km/h reverse, with neutral steering.\
 Main armament is the stabilized **40mm Akan m/70B** (24-round magazine) and a **7.62mm ksp 39 C** machine gun. The gunner has a laser rangefinder, FCS with lead, and Gen 2 green thermals; smoke grenades are fitted.
+The vehicle features two modifications: LEMUR and the slpprj m/01, both of which can be used in conjunction with each other. The LEMUR add-on gives the commander a CWS featuring Gen 2 thermals, a 3x-12x zoom, FCS, and Lead. It also features the 40mm MK-19 grenade launcher, which utilizes both HE and HEAT shells, making it perfect for killing light armour and infantry. The slpprj m/01 is an ammo add-on which replaces the stock slpprj m/90 APFSDS with slpprj m/01; this new shell boasts higher penetration, mass, and velocity, with the max pen going from 133mm for the slpprj m/90 to 175mm for the slpprj m/01.
 
 ## Armour
 

--- a/content/vehicles/supply-truck.md
+++ b/content/vehicles/supply-truck.md
@@ -6,7 +6,7 @@ frontArmorDepth: 100
 
 ## Description
 
-The **Supply Truck** is a Supply Truck — a wheeled logistics and troop carrier with minimal armour, intended for moving infantry and cargo rather than direct combat. In concept it resembles militarized medium trucks such as the M939 or similar 6×6 cargo trucks used for general support. The 11-tonne vehicle carries a driver, a gunner, and five passengers and is powered by a **6CTA8.3 IMO 1** diesel producing 240 horsepower for 21.8 hp/t and a top speed of 89 km/h. The gunner operates a stabilized **12.7mm M2** machine gun in an open mount for self-defense against infantry and light threats, with a 1x sight. The vehicle is resistant only to small arms and relies on speed and avoidance rather than protection.
+The **Supply Truck** is a wheeled logistics and troop carrier with minimal armour, intended for moving infantry and cargo rather than direct combat. In concept it resembles militarized medium trucks such as the M939 or similar 6×6 cargo trucks used for general support. The 11-tonne vehicle carries a driver, a gunner, and five passengers and is powered by a **6CTA8.3 IMO 1** diesel producing 240 horsepower for 21.8 hp/t and a top speed of 89 km/h. The gunner operates a stabilized **12.7mm M2** machine gun in an open mount for self-defense against infantry and light threats, with a 1x sight. The vehicle is resistant only to small arms and relies on speed and avoidance rather than protection. It also features Ammo crates and Jerry cans for rearming and refueling allied vehicles.
 
 ## Armour
 

--- a/content/vehicles/uaz-3909.md
+++ b/content/vehicles/uaz-3909.md
@@ -9,3 +9,7 @@ frontArmorDepth: 100
 The **UAZ 3909** is a Transport Vehicle based on the Russian UAZ "Jaguar" (UAZ-3909) family of 4×4 utility trucks, used for personnel and cargo in military and civilian roles. In-game it is a wheeled vehicle weighing 1.8 tonnes with seating for eight — one driver and seven passengers — and is unarmed. The **UMZ-417** diesel engine delivers 90 horsepower, giving an exceptional 50 hp/t power-to-weight ratio and a top speed of 115 km/h, making it one of the fastest light transports. With no turret or weapons, it relies on speed and low profile for survival.
 
 ## Armour
+
+Lower front plate: 0-5
+Upper front plate: 0
+Hull side: 0-5

--- a/content/vehicles/uaz-469.md
+++ b/content/vehicles/uaz-469.md
@@ -9,3 +9,7 @@ frontArmorDepth: 100
 The **UAZ 469** is a Transport Vehicle and the in-game representation of the Soviet and Russian **UAZ-469**, a 4×4 light utility vehicle produced by Ulyanovsky Avtomobilny Zavod since the early 1970s. The real vehicle has been widely used by military, police, and civilian operators for personnel transport, liaison, and towing in rough terrain. In-game it is a wheeled vehicle weighing 1.7 tonnes with seating for five — a driver and four passengers — and no armament. A **2445cc UMZ** diesel produces 75 horsepower for an exceptionally high 45.5 hp/t power-to-weight ratio and a top speed of 105 km/h forward and 22 km/h reverse. The vehicle is suited to rapid movement of small teams between positions.
 
 ## Armour
+
+Lower front plate: 0-5
+Upper front plate: 0
+Hull side: 0-5

--- a/content/vehicles/ural-375d.md
+++ b/content/vehicles/ural-375d.md
@@ -9,3 +9,7 @@ frontArmorDepth: 100
 The **Ural-375D** is a Supply Truck — the Soviet 6×6 cargo and troop carrier produced from 1961 by the Ural Automotive Plant, widely used for logistics, artillery tow, and general transport in Soviet and allied armies. In-game it is a wheeled vehicle weighing 13.2 tonnes with seating for six — one driver and five passengers — and is powered by a **ZiL-375** gasoline engine producing 180 horsepower for 13.6 hp/t and a top speed of 75 km/h forward and 15 km/h backward. It has no weapons or turrets and is used purely for moving personnel and cargo; addons include a flat bed and tent cover. The truck’s high mobility and capacity make it the backbone of resupply and troop movement in the field.
 
 ## Armour
+
+Lower front plate: 0-10
+Upper front plate: 0
+Hull side: 0-10

--- a/content/vehicles/willys-mb.md
+++ b/content/vehicles/willys-mb.md
@@ -10,3 +10,7 @@ The **Willys MB** is a Transport Vehicle — the iconic American World War II je
 The gunner operates a stabilized **12.7mm M2** machine gun on a ring mount with 1x optics; the vehicle has no armour to speak of and relies on speed and small size to avoid engagement.
 
 ## Armour
+
+Lower front plate: 0-5
+Upper front plate: 0
+Hull side: 0-5


### PR DESCRIPTION
Armour for:

MiKi Truck Company Model 2
BM-21 Grad
BMP-1TS
BMP-3 (2017)
Abandoned IFV Hull
CV 90120-T Ghost
Lada
LT-SE
M38
M939
MiKi Truck Company Model 1
RSZO-1
UAZ-3909
UAZ-469
Ural-375D
Willys MB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added or expanded armour specs for many vehicles (lower/upper front plates, hull sides, cheek plates, mantlets).
  * Reworded and clarified vehicle descriptions and names, including origin/designation, armament details, upgrade options, and added logistics/airdrop notes (e.g., supply truck now notes ammo crates and jerry cans).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->