### PR TITLE
Add burlaks faster APFSDS reload to desc

### DIFF
--- a/content/vehicles/burlak.md
+++ b/content/vehicles/burlak.md
@@ -7,7 +7,7 @@ frontArmorDepth: 58
 ## Description
 
 The **Burlak** is a Main Battle Tank combining a modern unmanned-style turret and the **125mm 2A82** gun with an older chassis, offering high firepower and an autoloader with a crew of three. The design reflects a trend toward reduced crew and improved situational awareness. The 49.5 t tracked vehicle is crewed by driver, gunner, and commander and reaches 60 km/h forward. The **ChTZ V-92S2** diesel produces 1,000 hp for 20.2 hp/t.\
-Main armament is the **125mm 2A82** with autoloader (6.8 s reload), 3BM69, 3BK18M, 9M119M1, and 3OF26; a coaxial **7.62mm PKT** and a commander **14.5mm KPVT** are fitted. The vehicle has an APS (14 launchers), LWS, MAWS, stabilizer, smoke grenades, and engine smoke. Optics include gunner 2.7x–12x and thermals (Gen 2), and commander CITV with Gen 2 thermals and laser, all with FCS and lead.
+Main armament is the **125mm 2A82** with autoloader (6.8 s reload, 4 s for 3BM69), 3BM69, 3BK18M, 9M119M1, and 3OF26; a coaxial **7.62mm PKT** and a commander **14.5mm KPVT** are fitted. The vehicle has an APS (14 launchers), LWS, MAWS, stabilizer, smoke grenades, and engine smoke. Optics include gunner 2.7x–12x and thermals (Gen 2), and commander CITV with Gen 2 thermals and laser, all with FCS and lead.
 
 ## Armour
 


### PR DESCRIPTION
Burlak's 3BM69 has a reload multi of 0.588x giving it a 4s reload compared to all other shells at 6.8s, adding info to make it known in description rather than having to go to shell info

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated vehicle armament specifications with more detailed reload time information for different ammunition types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->