### PR TITLE
fix(shells): penetration table LOS/REL toggle stacking values

### DIFF
--- a/src/components/features/shells/shell/penetrationTable.tsx
+++ b/src/components/features/shells/shell/penetrationTable.tsx
@@ -65,8 +65,8 @@ export default function ShellPenetrationTable() {
                 mode,
               );
 
-              const anglePenCells = anglePens.map((penetration) => (
-                <span key={`${distance}-${angle}-${penetration}`}>
+              const anglePenCells = anglePens.map((penetration, index) => (
+                <span key={`${mode}-${distance}-${angle}-${index}`}>
                   {penetration ? (
                     <FormatNumber
                       style="unit"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Toggling between LOS and REL in the shell penetration table could stack old and new numbers in the same cells, making the table grow visually.

## Cause

Each penetration value was rendered with `key={\`${distance}-${angle}-${penetration}\`}`. After converting to REL, several LOS values often round to the **same** millimeter, so React saw **duplicate keys** within a list. That breaks reconciliation: children can be reused incorrectly and previous DOM content can remain alongside updates.

## Fix

Use keys that are unique per row entry: include `mode` and the value’s **index** in the source array (`\`${mode}-${distance}-${angle}-${index}\``).

Committed on `cursor/penetration-table-old-values-528c`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b1b9c040-9287-4ba7-baab-d48f42e80444"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b1b9c040-9287-4ba7-baab-d48f42e80444"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the penetration table rendering to improve list item identification and consistency across different display modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->