### PR TITLE
Add armor for the M41A1 

### DIFF
--- a/content/vehicles/m41a1.md
+++ b/content/vehicles/m41a1.md
@@ -6,3 +6,10 @@ The **M41A1** is a Light Tank, representing the U.S. **M41 Walker Bulldog** fami
 The primary armament is the **76mm M32** cannon in a turret without a gun stabilizer, served by main and backup optical sights with 6× and 8× magnification and no laser rangefinder. A coaxial **7.62mm M1919A4E1** machine gun supports close targets, while a roof-mounted **12.7mm M2** provides additional suppressive and anti-aircraft capability from the commander’s station.
 
 ## Armour
+
+Left cheek: 40-169
+Right cheek: 36-165
+Lower front plate: 33-45
+Upper front plate: 25-100
+Hull side: 19-43
+Mantlet: 33-131


### PR DESCRIPTION
Added armor specifications for the M41A1 tank.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced M41A1 vehicle specifications with detailed armour profile data, including thickness information for key locations such as cheeks, front plates, hull side, and mantlet.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->