### PR TITLE
Borsuk armour values and descriptions and cheonma fix

### DIFF
--- a/content/vehicles/borsuk.md
+++ b/content/vehicles/borsuk.md
@@ -2,6 +2,9 @@
 
 ## Description
 
+The Borsuk is an infantry fighting vehicle produced by the Huta Stalowa Wola company. In service since 2025, it was designed as a replacement for Poland's ageing BMP fleet. In-game, it is a tracked, amphibious vehicle weighing 28 tonnes with a crew of three and six passengers; it is capable of 8 km/h in water. The MTU 8V199 TE20 diesel engine produces 720 hp (25.7 hp/t) for a top speed of 65 km/h in both forward and reverse.
+The turret mounts a 30mm Treemaster autocannon, Spike-LR2/MR FNF ATGMs, and a coaxial 7.62mm UKM-2000C. The vehicle has laser and missile warning systems, a stabiliser, smoke grenades, and an FCS with lead computation; the gunner’s sight has a laser rangefinder and Gen 3 "white-hot" thermals with 2x–15x zoom.
+
 ## Armour
 
 Left cheek: 20-76

--- a/content/vehicles/borsuk.md
+++ b/content/vehicles/borsuk.md
@@ -3,7 +3,7 @@
 ## Description
 
 The Borsuk is an infantry fighting vehicle produced by the Huta Stalowa Wola company. In service since 2025, it was designed as a replacement for Poland's ageing BMP fleet. In-game, it is a tracked, amphibious vehicle weighing 28 tonnes with a crew of three and six passengers; it is capable of 8 km/h in water. The MTU 8V199 TE20 diesel engine produces 720 hp (25.7 hp/t) for a top speed of 65 km/h in both forward and reverse.
-The turret mounts a 30mm Treemaster autocannon, Spike-LR2/MR FNF ATGMs, and a coaxial 7.62mm UKM-2000C. The vehicle has laser and missile warning systems, a stabiliser, smoke grenades, and an FCS with lead computation; the gunner’s sight has a laser rangefinder and Gen 3 "white-hot" thermals with 2x–15x zoom.
+The turret mounts a 30mm Treemaster autocannon, Spike-LR2/MR FNF ATGMs, and a coaxial 7.62mm UKM-2000C. The vehicle has laser and missile warning systems, a stabiliser, smoke grenades, and an FCS with lead computation and target locking; the gunner’s sight has a laser rangefinder and Gen 3 "white-hot" thermals.
 
 ## Armour
 

--- a/content/vehicles/borsuk.md
+++ b/content/vehicles/borsuk.md
@@ -2,8 +2,8 @@
 
 ## Description
 
-The Borsuk is an infantry fighting vehicle produced by the Huta Stalowa Wola company. In service since 2025, it was designed as a replacement for Poland's ageing BMP fleet. In-game, it is a tracked, amphibious vehicle weighing 28 tonnes with a crew of three and six passengers; it is capable of 8 km/h in water. The MTU 8V199 TE20 diesel engine produces 720 hp (25.7 hp/t) for a top speed of 65 km/h in both forward and reverse.
-The turret mounts a 30mm Treemaster autocannon, Spike-LR2/MR FNF ATGMs, and a coaxial 7.62mm UKM-2000C. The vehicle has laser and missile warning systems, a stabiliser, smoke grenades, and an FCS with lead computation and target locking; the gunner’s sight has a laser rangefinder and Gen 3 "white-hot" thermals.
+The **Borsuk** is an infantry fighting vehicle produced by the Huta Stalowa Wola company. In service since 2025, it was designed as a replacement for Poland's ageing BMP fleet. In-game, it is a tracked, amphibious vehicle weighing 28 tonnes with a crew of three and six passengers; it is capable of 8 km/h in water. The **MTU 8V199 TE20** diesel engine produces 720 hp (25.7 hp/t) for a top speed of 65 km/h in both forward and reverse.
+The turret mounts a **30mm Treemaster** autocannon, **Spike-LR2/MR FNF ATGMs**, and a coaxial **7.62mm UKM-2000C**. The vehicle has laser and missile warning systems, a stabiliser, smoke grenades, and an FCS with lead computation and target locking; the gunner’s sight has a laser rangefinder and Gen 3 "white-hot" thermals.
 
 ## Armour
 

--- a/content/vehicles/borsuk.md
+++ b/content/vehicles/borsuk.md
@@ -3,3 +3,10 @@
 ## Description
 
 ## Armour
+
+Left cheek: 20-76
+Right cheek: 11-27
+Lower front plate: 96-246
+Upper front plate: 50-292
+Hull side: 43-89
+Mantlet: 20-105

--- a/content/vehicles/cheonma-2.md
+++ b/content/vehicles/cheonma-2.md
@@ -7,7 +7,7 @@ frontArmorDepth: 62
 ## Description
 
 The **Cheonma-2** is a Main Battle Tank developed by North Korea, evolving from the Soviet [[/vehicles/t-62 T-62]] lineage with a new turret and improved mobility and protection. The type has been fielded in limited numbers and represents the country's effort to modernize its armored force. The 56 t tracked vehicle is crewed by four — driver, gunner, commander, and loader — and reaches 75 km/h forward and 34 km/h reverse. An **HP150** diesel produces 1,500 hp for a 26.8 hp/t power-to-weight ratio and an automatic gearbox.\
-Main armament is the **125mm 2A46NK** with an autoloader (5.3 s reload), plus a coaxial **7.62mm PKT** and a **Bulsae-3** ATGM launcher; a loader-operated **30mm AGS-17** grenade launcher is also fitted. The vehicle has an APS (12 launchers), LWS, MAWS, stabilizer, and smoke grenades; the gunner and commander sights have Gen 3 thermals, laser rangefinder, and FCS with lead and tracking. An engine smoke system is standard.
+Main armament is the **125mm 2A46NK** with a 5.3 s reload, plus a coaxial **7.62mm PKT** and a **Bulsae-3** ATGM launcher; a loader-operated **30mm AGS-17** grenade launcher is also fitted. The vehicle has an APS (12 launchers), LWS, MAWS, stabilizer, and smoke grenades; the gunner and commander sights have Gen 3 thermals, laser rangefinder, and FCS with lead and tracking. An engine smoke system is standard.
 This vehicle features a single addon: **Model 2024**. The Model 2024 addon costs 250 points and equips the Cheonma-2 with ERA on the hull sides and turret. This upgrade significantly increases the overall protection levels for both the hull and turret, providing a vital layer of defense against chemical energy munitions and ATGMs.
 
 ## Armour


### PR DESCRIPTION
Borsuk armour values and descriptions, sight zooms may be wrong because i dont know the formula

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded Borsuk vehicle entry with detailed description: manufacturer/origin, service timing, in-game role, mobility, engine and speed figures, crew/passenger, armament, sensors/fire-control, and detailed armour protection across multiple hull and turret zones.
  * Updated Cheonma-2 main armament description to remove an explicit autoloader mention while keeping reload time and other armament/sighting/FCS details.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/grand-hawk/public-stats-next/pull/223?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->