### PR TITLE
refactor(vehicles): rename stopping distance label to Vmax - 0

### DIFF
--- a/src/components/features/vehicles/vehicle/dynamic/modules/performance/index.tsx
+++ b/src/components/features/vehicles/vehicle/dynamic/modules/performance/index.tsx
@@ -175,7 +175,7 @@ export default function Performance() {
               </StatsCell>
             </StatsRow>
             <StatsRow>
-              <StatsCell>Stopping distance from Vmax</StatsCell>
+              <StatsCell>Vmax - 0</StatsCell>
               <StatsCell>
                 <FormatNumber
                   maximumFractionDigits={1}


### PR DESCRIPTION
---
_Generated by [Claude Code](https://claude.ai/code/session_01NRwwR48jDWJ943Ja8mShuA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the braking statistic label to clearly display “Vmax - 0,” while preserving the existing stopping-distance value and unit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->